### PR TITLE
[BUGFIX] Selector precedence pseudos/attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Calculation of selector precedence for selectors involving pseudo-classes
+  and/or attributes.
 
 
 ## 2.0.0

--- a/src/Emogrifier.php
+++ b/src/Emogrifier.php
@@ -1404,18 +1404,24 @@ class Emogrifier
         $selectorKey = md5($selector);
         if (!isset($this->caches[static::CACHE_KEY_SELECTOR][$selectorKey])) {
             $precedence = 0;
-            $value = 100;
-            // ids: worth 100, classes: worth 10, elements: worth 1
-            $search = ['\\#', '\\.', ''];
+            $value = 10000;
+            $search = [
+                // ids: worth 10000
+                '\\#',
+                // classes, attributes, pseudo-classes (not pseudo-elements) except `:not`: worth 100
+                '(?:\\.|\\[|(?<!:):(?!not\\())',
+                // elements (not attribute values or `:not`), pseudo-elements: worth 1
+                '(?:(?<![="\':\\w-])|::)'
+            ];
 
             foreach ($search as $s) {
                 if (trim($selector) === '') {
                     break;
                 }
                 $number = 0;
-                $selector = preg_replace('/' . $s . '\\w+/', '', $selector, -1, $number);
+                $selector = preg_replace('/' . $s . '[\\w-]++/', '', $selector, -1, $number);
                 $precedence += ($value * $number);
-                $value /= 10;
+                $value /= 100;
             }
             $this->caches[static::CACHE_KEY_SELECTOR][$selectorKey] = $precedence;
         }

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -706,7 +706,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
             'id more specific than class and types' => ['#p4', 'html body .p-4', '>', '<p class="p-4" id="p4"'],
             'id more specific than 20 classes and types'
                 => ['#p4', 'html body ' . str_repeat('.p-4', 20), '>', '<p class="p-4" id="p4"'],
-            'psuedo-class as specific as class' => ['.p-1', '*:first-child', '==', '<p class="p-1"'],
+            'pseudo-class as specific as class' => ['.p-1', '*:first-child', '==', '<p class="p-1"'],
             'attribute as specific as class' => ['span[title="bonjour"]', '.p-2 span', '==', '<span title="bonjour"'],
             ':not alone does not increase specificity' => ['p:not(* + *)', 'p', '==', '<p class="p-1"'],
             ':not with type more specific than nothing' => ['.p-1:not(h1)', '.p-1', '>', '<p class="p-1"'],

--- a/tests/Unit/EmogrifierTest.php
+++ b/tests/Unit/EmogrifierTest.php
@@ -18,6 +18,22 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     const LF = "\n";
 
     /**
+     * @var string Common HTML markup with a variety of elements and attributes for testing with
+     */
+    const COMMON_TEST_HTML = '
+        <html>
+            <body>
+                <p class="p-1"><span>some text</span></p>
+                <p class="p-2"><span title="bonjour">some</span> text</p>
+                <p class="p-3"><span title="buenas dias">some</span> more text</p>
+                <p class="p-4" id="p4"><span title="avez-vous">some</span> more text</p>
+                <p class="p-5 additional-class"><span title="buenas dias bom dia">some</span> more text</p>
+                <p class="p-6"><span title="title: subtitle; author">some</span> more text</p>
+            </body>
+        </html>
+    ';
+
+    /**
      * @var string
      */
     private $html5DocumentType = '<!DOCTYPE html>';
@@ -572,19 +588,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $html = '
-            <html>
-                <body>
-                    <p class="p-1"><span>some text</span></p>
-                    <p class="p-2"><span title="bonjour">some</span> text</p>
-                    <p class="p-3"><span title="buenas dias">some</span> more text</p>
-                    <p class="p-4" id="p4"><span title="avez-vous">some</span> more text</p>
-                    <p class="p-5 additional-class"><span title="buenas dias bom dia">some</span> more text</p>
-                    <p class="p-6"><span title="title: subtitle; author">some</span> more text</p>
-                </body>
-            </html>
-            ';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml(static::COMMON_TEST_HTML);
         $this->subject->setCss(sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
         $result = $this->subject->emogrify();
@@ -672,19 +676,7 @@ class EmogrifierTest extends \PHPUnit_Framework_TestCase
     {
         $cssDeclaration1 = 'color: red;';
         $cssDeclaration2 = 'text-align: left;';
-        $html = '
-            <html>
-                <body>
-                    <p class="p-1"><span>some text</span></p>
-                    <p class="p-2"><span title="bonjour">some</span> text</p>
-                    <p class="p-3"><span title="buenas dias">some</span> more text</p>
-                    <p class="p-4" id="p4"><span title="avez-vous">some</span> more text</p>
-                    <p class="p-5 additional-class"><span title="buenas dias bom dia">some</span> more text</p>
-                    <p class="p-6"><span title="title: subtitle; author">some</span> more text</p>
-                </body>
-            </html>
-            ';
-        $this->subject->setHtml($html);
+        $this->subject->setHtml(static::COMMON_TEST_HTML);
         $this->subject->setCss(sprintf($css, $cssDeclaration1, $cssDeclaration2));
 
         $result = $this->subject->emogrify();


### PR DESCRIPTION
Corrected selector precedence calculation for selectors involving
pseudo-classes and/or attributes (ref:
https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity).

Increased multiplier for selector type to allow up to 100 of each type.

Added PHPUnit tests for selector precedence.  Moved common testing HTML to a
constant.